### PR TITLE
Add progress info about number of received packets

### DIFF
--- a/src/model/measurements_manager.py
+++ b/src/model/measurements_manager.py
@@ -11,11 +11,13 @@ class MeasurementsManager:
         self.serial_conn = serial_conn
         self.points_number = points_number
         self.timeout = timeout
+        self.received = 0
 
     def measure_point(self) -> Optional[Tuple[float, float]]:
+        self.received = 0
         rssi_values: List[int] = []
         start = time.time()
-        while time.time() - start < self.timeout and len(rssi_values) < self.points_number:
+        while time.time() - start < self.timeout and self.received < self.points_number:
             bytes_to_read = self.serial_conn.ser.inWaiting()
             text_read = self.serial_conn.ser.read(bytes_to_read).decode(encoding='utf-8')
             if text_read:
@@ -26,6 +28,7 @@ class MeasurementsManager:
                         logger.debug(f"Read RSSI value from serial: {rssi}")
                         try:
                             rssi_values.append(int(rssi))
+                            self.received += 1
                         except Exception as ex:
                             print(ex)
             time.sleep(0.1)

--- a/src/model/model.py
+++ b/src/model/model.py
@@ -49,6 +49,9 @@ class Model:
     def get_program_data(self):
         return self.program_data
 
+    def get_received_status(self):
+        return self.measurements_mgr.received
+
     def measure_point_by_coordinates(self, x: int, y: int):
         id = self.measurements_map.find_point_id(x, y)
         self.measure_point_by_id(id)

--- a/src/presenter/presenter.py
+++ b/src/presenter/presenter.py
@@ -49,3 +49,6 @@ class Presenter:
         fig = self.model.get_map_with_rssi_values()
         self.model.save_plot()
         self.view.render_map(fig)
+
+    def get_received_status(self):
+        return self.model.get_received_status()

--- a/src/view/view_gui.py
+++ b/src/view/view_gui.py
@@ -167,4 +167,3 @@ class ViewGUI(View):
             self.received_status = received
         self._update_measurement_progress_label()
         self._root.after(200, self._refresh_received_status)
-

--- a/src/view/view_gui.py
+++ b/src/view/view_gui.py
@@ -36,6 +36,7 @@ class ViewGUI(View):
         self._check_queue()
         self.fields = DEFAULT_FIELDS
         self._update_program_data()
+        self.received_status = 0
 
     def show(self):
         self._root.title("RSSIMapper")
@@ -84,6 +85,7 @@ class ViewGUI(View):
         self._progress_label = tk.Label(self.tab2)
         self._progress_label.pack()
         self._presenter.update_map()
+        self._refresh_received_status()
         self._root.mainloop()
 
     def browse_files(self, field):
@@ -144,7 +146,9 @@ class ViewGUI(View):
             logger.debug('Clicked outside axes bounds but inside plot window')
 
     def _update_measurement_progress_label(self):
-        self._progress_label.config(text="Measurement in progress...")
+        self._progress_label.config(text=f"Measurement in progress... "
+                                         f"Received: "
+                                         f"{self.received_status}/{self.entries['n_measurements_per_point'].get()}")
 
     def _clear_measurement_progress_label(self):
         self._progress_label.config(text="")
@@ -156,3 +160,11 @@ class ViewGUI(View):
             else:
                 self.fields[field] = val.get()
         self._update_program_data()
+
+    def _refresh_received_status(self):
+        received = self._presenter.get_received_status()
+        if self.received_status != received:
+            self.received_status = received
+        self._update_measurement_progress_label()
+        self._root.after(200, self._refresh_received_status)
+

--- a/src/view/view_gui.py
+++ b/src/view/view_gui.py
@@ -145,7 +145,7 @@ class ViewGUI(View):
 
     def _save_settings(self):
         self._update_program_data()
-                                    
+
     def _fetch_saved_settings(self):
         return self._presenter.fetch_saved_settings()
 


### PR DESCRIPTION
**What?**

I have added a periodic check if new packets were received. This is then showed to the user as a progress of how many packets were already received of the total amount of packets that are expected to be received in this measure point. Closes #48 

**Why?**

It improves user experience when the user can see that something is happening during the 1 min time that the measurement of a single point takes.

**How?**

I have used a periodic check in view class. I chose this method because as per MVP (Model-View-Presenter) model, the model should not know about the presenter or view, so there is no way to notify the view about the packet that was received. On the contrary, the view must check if model changed.